### PR TITLE
refactor(rust): apply linter (clippy) suggestions

### DIFF
--- a/snake-rust/src/snake.rs
+++ b/snake-rust/src/snake.rs
@@ -95,8 +95,7 @@ impl Snake {
                 .body
                 .iter()
                 .skip(1)
-                .find(|&body_section| body_section == first)
-                .is_some(),
+                .any(|body_section| body_section == first),
         }
     }
 }


### PR DESCRIPTION
```bash
$ cargo clippy
warning: called `is_some()` after searching an `Iterator` with `find`
  --> src/snake.rs:98:18
   |
98 |                   .find(|&body_section| body_section == first)
   |  __________________^
99 | |                 .is_some(),
   | |__________________________^ help: use `any()` instead: `any(|body_section| body_section == first)`
   |
   = note: `#[warn(clippy::search_is_some)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some
  ```

- https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some